### PR TITLE
Update to Common.Logging 3.0

### DIFF
--- a/Topshelf.Common.Logging.csproj
+++ b/Topshelf.Common.Logging.csproj
@@ -31,7 +31,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Common.Logging">
-      <HintPath>..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <HintPath>packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -41,7 +44,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Topshelf">
-      <HintPath>..\packages\Topshelf.3.1.1\lib\net40-full\Topshelf.dll</HintPath>
+      <HintPath>packages\Topshelf.3.1.4\lib\net40-full\Topshelf.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="2.1.2" targetFramework="net40" />
-  <package id="Topshelf" version="3.1.1" targetFramework="net40" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net40" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net40" />
+  <package id="Topshelf" version="3.1.4" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
The API changes in Common.Logging 3.0 cause TypeLoadExceptions when calling UseCommonLogging() because it expects to find ILog in Common.Logging, rather than Common.Logging.Core. Recompiling Topshelf.Common.Logging against Common.Logging 3.0 resolves this issue.

The nuspec will need to be updated with a minimum Common.Logging version of 3.0 to reflect this change, along with a major version number change, however it isn't included in the repository so I could not make the changes myself.
